### PR TITLE
config::project_repos optional

### DIFF
--- a/.sqa/config.yml
+++ b/.sqa/config.yml
@@ -9,4 +9,6 @@ sqa_criteria:
       jpl-validator:
         container: gradle
         commands:
+            - ls -la /jpl-validator
+            - env
             - /jpl-validator/gradlew -p /jpl-validator jib

--- a/.sqa/config.yml
+++ b/.sqa/config.yml
@@ -1,8 +1,4 @@
 config:
-  project_repos:
-    jpl-validator:
-      repo: 'https://github.com/eosc-synergy/jpl-validator'
-      branch: master
   credentials:
       - type: username_password
         id: orviz-dockerhub

--- a/.sqa/docker-compose.yml
+++ b/.sqa/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     hostname: "jpl-validator"
     volumes:
       - type: bind
-        source: ./jpl-validator
+        source: ./
         target: /jpl-validator
     command: sleep infinity

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library(['github.com/indigo-dc/jenkins-pipeline-library@release/2.1.0']) _
+@Library(['github.com/indigo-dc/jenkins-pipeline-library@feature/triggered-branch-only']) _
 
 def projectConfig
 
@@ -12,12 +12,13 @@ pipeline {
                     branch 'master'
                     branch 'jib-with-jpl'
                     buildingTag()
+		    branch 'feature/triggered-branch-only'
                 }
             }
             steps {
                 script {
-                    //projectConfig = pipelineConfig('./.sqa/config.yml', null, null, 'eoscsynergy/jpl-validator:jib-with-jpl')
-                    projectConfig = pipelineConfig('./.sqa/config.yml')
+                    projectConfig = pipelineConfig('./.sqa/config.yml', null, null, 'eoscsynergy/jpl-validator:feature/triggered-branch-only')
+                    //projectConfig = pipelineConfig('./.sqa/config.yml')
                     buildStages(projectConfig)
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             }
             steps {
                 script {
-                    projectConfig = pipelineConfig('./.sqa/config.yml', null, null, 'worsica/jpl-validator:triggered-branch-only')
+                    projectConfig = pipelineConfig('./.sqa/config.yml', null, null, 'eoscsynergy/jpl-validator:triggered-branch-only')
                     //projectConfig = pipelineConfig('./.sqa/config.yml')
                     buildStages(projectConfig)
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,7 @@ pipeline {
             }
             steps {
                 script {
-                    projectConfig = pipelineConfig('./.sqa/config.yml', null, null, 'eoscsynergy/jpl-validator:triggered-branch-only')
-                    //projectConfig = pipelineConfig('./.sqa/config.yml')
+                    projectConfig = pipelineConfig('./.sqa/config.yml')
                     buildStages(projectConfig)
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,9 @@ pipeline {
         stage('SQA baseline dynamic stages') {
             when {
                 anyOf {
-                    branch 'master'
-                    branch 'jib-with-jpl'
+                    branch 'refs/heads/*'
                     buildingTag()
-                    changeRequest branch: 'triggered-branch-only'
+                    not { changeRequest() }
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                     branch 'master'
                     branch 'jib-with-jpl'
                     buildingTag()
-            branch 'triggered-branch-only'
+                    changeRequest branch: 'triggered-branch-only'
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,12 +12,12 @@ pipeline {
                     branch 'master'
                     branch 'jib-with-jpl'
                     buildingTag()
-		    branch 'triggered-branch-only'
+            branch 'triggered-branch-only'
                 }
             }
             steps {
                 script {
-                    projectConfig = pipelineConfig('./.sqa/config.yml', null, null, 'eoscsynergy/jpl-validator:feature/triggered-branch-only')
+                    projectConfig = pipelineConfig('./.sqa/config.yml', null, null, 'worsica/jpl-validator:triggered-branch-only')
                     //projectConfig = pipelineConfig('./.sqa/config.yml')
                     buildStages(projectConfig)
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                     branch 'master'
                     branch 'jib-with-jpl'
                     buildingTag()
-		    branch 'feature/triggered-branch-only'
+		    branch 'triggered-branch-only'
                 }
             }
             steps {

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,7 @@ project.ext.organization = 'eoscsynergy'
 
 // Google's jib task
 jib.container.mainClass = mainClassName
-//jib.to.image = "${project.ext.organization}/${project.name}:${version}"
-jib.to.image = "${project.ext.organization}/${project.name}:triggered-branch-only"
+jib.to.image = "${project.ext.organization}/${project.name}:${version}"
 jib.to.auth.username = "${System.env.JPL_USERNAME}"
 jib.to.auth.password = "${System.env.JPL_PASSWORD}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ def details = versionDetails()
 
 mainClassName = 'eu.indigo.jplvalidator.Cli'
 version = details.branchName
-project.ext.organization = 'worsica'
+project.ext.organization = 'eoscsynergy'
 
 // Google's jib task
 jib.container.mainClass = mainClassName

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ project.ext.organization = 'eoscsynergy'
 
 // Google's jib task
 jib.container.mainClass = mainClassName
-jib.to.image = "${project.ext.organization}/${project.name}:${version}"
+//jib.to.image = "${project.ext.organization}/${project.name}:${version}"
+jib.to.image = "${project.ext.organization}/${project.name}:triggered-branch-only"
 jib.to.auth.username = "${System.env.JPL_USERNAME}"
 jib.to.auth.password = "${System.env.JPL_PASSWORD}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 def details = versionDetails()
 
 mainClassName = 'eu.indigo.jplvalidator.Cli'
-version = "${details.branchName}"
+version = details.branchName
 project.ext.organization = 'eoscsynergy'
 
 // Google's jib task

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ def details = versionDetails()
 
 mainClassName = 'eu.indigo.jplvalidator.Cli'
 version = details.branchName
-project.ext.organization = 'eoscsynergy'
+project.ext.organization = 'worsica'
 
 // Google's jib task
 jib.container.mainClass = mainClassName

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 def details = versionDetails()
 
 mainClassName = 'eu.indigo.jplvalidator.Cli'
-version = details.branchName
+version = "${details.branchName}"
 project.ext.organization = 'eoscsynergy'
 
 // Google's jib task

--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -19,7 +19,6 @@
         },
         "config_repo": {
             "type": "object",
-            "minProperties": 1,
             "patternProperties": {
                 "[a-z0-9_]*": { "$ref": "#/definitions/config_repo_settings" }
             }

--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -213,8 +213,7 @@
                     }
                 }
             },
-            "additionalProperties": false,
-            "required": ["project_repos"]
+            "additionalProperties": false
         },
         "sqa_criteria": {
             "description": "Contains all the required SQA baseline's criteria definitions",


### PR DESCRIPTION
For the use cases that only need the triggered branch is not required to defined any config::project_repos.
This also bring changes to config.yml, docker-compose.yml and Jenkinsfile that may be discarded to target branch of this PR.