### PR TITLE
Criterion without repos

### DIFF
--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -173,6 +173,13 @@
             "required": ["repos"],
             "additionalProperties": false
         },
+        "sqa_criterion": {
+            "type": "object",
+            "oneOf": [
+                { "$ref": "#/definitions/sqa_criterion_with_repos" },
+                { "$ref": "#/definitions/repo_settings" }
+            ]
+        },
         "environment": {
             "description": "Sets the environment variables required for the runtime context",
             "type": "object",

--- a/src/main/resources/schema.json
+++ b/src/main/resources/schema.json
@@ -158,17 +158,17 @@
                 "tox": ["container"]
             }
         },
-        "sqa_criterion_repo": {
+        "sqa_criterion_reponame": {
             "type": "object",
             "minProperties": 1,
             "patternProperties": {
                 "[a-z0-9_-]*": { "$ref": "#/definitions/repo_settings" }
             }
         },
-        "sqa_criterion": {
+        "sqa_criterion_with_repos": {
             "type": "object",
             "properties": {
-                "repos": { "$ref": "#/definitions/sqa_criterion_repo" }
+                "repos": { "$ref": "#/definitions/sqa_criterion_reponame" }
             },
             "required": ["repos"],
             "additionalProperties": false


### PR DESCRIPTION
This change will allow JePL users to avoid the current need of declaring the repo name (within the `sqa_criteria` property) in the cases where the build has been triggered automatically (so the repo version will be the one from the change). E.g. we will allow:
```yaml
sqa_criteria:
  QC.Sty:
    container: <container-label>
    commands: <list-of-commands>
```

instead of the current & mandatory way:
```yaml
sqa_criteria:
  QC.Sty:
    repos:
      <repo-name>:
        container: <container-label>
        commands: <list-of-commands>
```